### PR TITLE
Resolved Issue #18: Converted the call from getDate to getTimestamp for Date conversion

### DIFF
--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/mappers/DefaultObjectMapperRsExtractors.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/mappers/DefaultObjectMapperRsExtractors.java
@@ -27,7 +27,7 @@ public class DefaultObjectMapperRsExtractors {
     }
 
     private static void javaDate(Map<Class, ObjectMapperRsExtractor<?>> exs) {
-        reg(exs, java.util.Date.class, ResultSet::getDate);
+        reg(exs, java.util.Date.class, ResultSet::getTimestamp);
     }
 
     private static void javaTimeTypes(Map<Class, ObjectMapperRsExtractor<?>> exs) {


### PR DESCRIPTION
Converted the call from getDate to getTimestamp so that time information is not lost once date component in Pojo is formatted for display.