### PR TITLE
add failing tests for lazy connection provision during transactions

### DIFF
--- a/fluent-jdbc/src/test/groovy/org/codejargon/fluentjdbc/internal/query/FluentJdbcTransactionTest.groovy
+++ b/fluent-jdbc/src/test/groovy/org/codejargon/fluentjdbc/internal/query/FluentJdbcTransactionTest.groovy
@@ -79,12 +79,17 @@ class FluentJdbcTransactionTest extends UpdateTestBase {
     }
 
     def "Transactions are lazy"() {
-        given:
-        preparedStatement.executeUpdate() >> expectedUpdatedRows.intValue()
         when:
-        query.transaction().inNoResult({ -> });
+        query.transaction().inNoResult({ -> /* not using query */ });
         then:
-        0 * connection.setAutoCommit(false)
+        connectionProvided == 0
+    }
+    
+    def "Nested transactions are lazy"() {
+        when:
+        query.transaction().inNoResult({ -> query.transaction().inNoResult({ -> /* not using query */ })});
+        then:
+        connectionProvided == 0
     }
 
     def "Transaction isolation"() {


### PR DESCRIPTION
It's convenient so say at a high level in the architecture: "If interaction with the database is necessary, run everything in the same transaction". Right now the `Transaction::in` family of methods provide this.

However, if no database calls turn out to be necessary further down into the callback, a connection still gets checked out of the connection pool / held open for the duration of the callback.

This pull requests just makes the laziness requirement for transactions a bit stricter.
I tried to add this behavior in the current code, but I didn't find a clean way that doesn't break compatibility.

This is essentially what [LazyConnectionDataSourceProxy](http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/jdbc/datasource/LazyConnectionDataSourceProxy.html) from spring does, but it might be nice to have this by default in fluent-jdbc.

Do you think this is worth doing? I'm happy to create another pull request if you have any pointers.