### PR TITLE
Provide query parameters to execution listener

### DIFF
--- a/fluent-jdbc/.gitignore
+++ b/fluent-jdbc/.gitignore
@@ -1,0 +1,5 @@
+/target/
+/.settings/
+/.classpath
+/.project
+/*.log

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/api/mapper/CallableMappers.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/api/mapper/CallableMappers.java
@@ -1,0 +1,57 @@
+package org.codejargon.fluentjdbc.api.mapper;
+
+import java.math.BigDecimal;
+
+import org.codejargon.fluentjdbc.api.query.CallableMapper;
+
+/**
+ * <p>A set of common mappers for convenience.</p>
+ * @see org.codejargon.fluentjdbc.api.mapper.ObjectMappers
+ */
+public abstract class CallableMappers {
+    private static final CallableMapper<Integer> singleInteger = (cs) -> cs.getInt(1);
+    private static final CallableMapper<Long> singleLong = (cs) -> cs.getLong(1);
+    private static final CallableMapper<String> singleString = (cs) -> cs.getString(1);
+    private static final CallableMapper<BigDecimal> singleBigDecimal = (cs) -> cs.getBigDecimal(1);
+    private static final CallableMapper<Boolean> singleBoolean = (cs) -> cs.getBoolean(1);
+
+    /**
+     * Maps the first Integer column.
+     * @return first Integer column
+     */
+    public static CallableMapper<Integer> singleInteger() {
+        return singleInteger;
+    }
+
+    /**
+     * Maps the first Long column.
+     * @return first Long column
+     */
+    public static CallableMapper<Long> singleLong() {
+        return singleLong;
+    }
+
+    /**
+     * Maps the first string column
+     * @return first string column
+     */
+    public static CallableMapper<String> singleString() {
+        return singleString;
+    }
+
+    /**
+     * Maps the first BigDecimal column
+     * @return first BigDecimal column
+     */
+    public static CallableMapper<BigDecimal> singleBigDecimal() {
+        return singleBigDecimal;
+    }
+
+    /**
+     * Maps the first Boolean column
+     * @return first Boolean column
+     */
+    public static CallableMapper<Boolean> singleBoolean() {
+        return singleBoolean;
+    }
+}

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/api/query/CallableMapper.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/api/query/CallableMapper.java
@@ -1,0 +1,20 @@
+/*
+* $Id: $
+*
+* Copyright (c) 2021, CGI. All rights reserved.
+* CGI PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+*/
+package org.codejargon.fluentjdbc.api.query;
+
+import java.sql.CallableStatement;
+import java.sql.SQLException;
+
+/**
+ * The {@code CallableResultMapper} class implements ... 
+ * TODO write proper class description
+ * 
+ * @author wiedermanna
+ */
+public interface CallableMapper<T> {
+    T map(CallableStatement statement) throws SQLException;
+}

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/api/query/CallableQuery.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/api/query/CallableQuery.java
@@ -1,0 +1,61 @@
+package org.codejargon.fluentjdbc.api.query;
+
+import java.sql.CallableStatement;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Select query for a SQL statement. A SelectQuery is mutable, non-threadsafe.
+ */
+public interface CallableQuery {
+    /**
+     * Adds positional query parameters.
+     *
+     * @param params additional query parameters
+     * @return this
+     */
+    CallableQuery params(List<?> params);
+
+    /**
+     * Adds positional query parameters.
+     *
+     * @param params additional query parameters
+     * @return this
+     */
+    CallableQuery params(Object... params);
+
+    /**
+     * Adds named query paramaters.
+     *
+     * @param namedParams additional named query parameters
+     * @return this
+     */
+    CallableQuery namedParams(Map<String, ?> namedParams);
+
+    /**
+     * Adds a named query parameter
+     *
+     * @param name name of parameter
+     * @param parameter value of parameter
+     * @return this
+     */
+    CallableQuery namedParam(String name, Object parameter);
+
+    /**
+     * Sets a custom error handler
+     *
+     * @param sqlErrorHandler
+     * @return this
+     */
+    CallableQuery errorHandler(SqlErrorHandler sqlErrorHandler);
+
+    /**
+     * executes the callable statement and returns a single result.
+     *
+     * @param mapper {@link CallableStatement} mapper
+     * @param <T> result type
+     * @return exactly one result
+     * @throws org.codejargon.fluentjdbc.api.FluentJdbcException if no result found
+     */
+    <T> T result(CallableMapper<T> mapper);
+}

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/api/query/Query.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/api/query/Query.java
@@ -2,10 +2,6 @@ package org.codejargon.fluentjdbc.api.query;
 
 import org.codejargon.fluentjdbc.api.query.inspection.DatabaseInspection;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.function.Function;
-
 /**
  * <p>FluentJdbc Query API to create select, update/insert, and batch update/insert queries. Immutable, thread-safe.</p>
  * @see org.codejargon.fluentjdbc.api.integration.ConnectionProvider
@@ -34,6 +30,14 @@ public interface Query {
      * @return Batch update or insert query for the SQL statement
      */
     BatchQuery batch(String sql);
+
+    /**
+     * Creates a callable query for SQL statement
+     * 
+     * @param sql callable SQL statement
+     * @return callable query for SQL statement
+     */
+    CallableQuery call(String sql);
 
     /**
      * Transaction control

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/api/query/SqlErrorHandler.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/api/query/SqlErrorHandler.java
@@ -3,6 +3,8 @@ package org.codejargon.fluentjdbc.api.query;
 import java.sql.SQLException;
 import java.util.Optional;
 
+import org.codejargon.fluentjdbc.internal.query.QueryInfoInternal;
+
 public interface SqlErrorHandler {
     enum Action {
         RETRY
@@ -17,5 +19,5 @@ public interface SqlErrorHandler {
      * @param sql The sql query. Always present unless the error was thrown by direct plainConnection() usage.
      * @return In case no exception is thrown, otherwise action needs to be returned ( eg retry ).
      */
-    Action handle(SQLException e, Optional<String> sql) throws SQLException;
+    Action handle(SQLException e, Optional<QueryInfoInternal> sql) throws SQLException;
 }

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/api/query/SqlErrorHandler.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/api/query/SqlErrorHandler.java
@@ -3,7 +3,7 @@ package org.codejargon.fluentjdbc.api.query;
 import java.sql.SQLException;
 import java.util.Optional;
 
-import org.codejargon.fluentjdbc.internal.query.QueryInfoInternal;
+import org.codejargon.fluentjdbc.api.query.listen.QueryInfo;
 
 public interface SqlErrorHandler {
     enum Action {
@@ -11,13 +11,16 @@ public interface SqlErrorHandler {
     }
 
     /**
-     * Handles SQL errors, may implement logging, etc. The handler should always rethrow an exception in case of
-     * a critical error. Otherwise retry action can be triggered. The handler is responsible to implement
-     * delay or limitations for the retry.
+     * Handles SQL errors, may implement logging, etc. The handler should always
+     * re-throw an exception in case of a critical error. Otherwise retry action can
+     * be triggered. The handler is responsible to implement delay or limitations
+     * for the retry.
      *
-     * @param e the error
-     * @param sql The sql query. Always present unless the error was thrown by direct plainConnection() usage.
-     * @return In case no exception is thrown, otherwise action needs to be returned ( eg retry ).
+     * @param e         the error
+     * @param queryInfo Query info including the SQL query. Always present unless
+     *                  the error was thrown by direct plainConnection() usage.
+     * @return In case no exception is thrown, otherwise action needs to be returned
+     *         ( eg retry ).
      */
-    Action handle(SQLException e, Optional<QueryInfoInternal> sql) throws SQLException;
+    Action handle(SQLException e, Optional<QueryInfo> queryInfo) throws SQLException;
 }

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/api/query/listen/ExecutionDetails.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/api/query/listen/ExecutionDetails.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 public interface ExecutionDetails {
     Boolean success();
-    String sql();
+    QueryInfo queryInfo();
     Long executionTimeMs();
     Optional<SQLException> sqlException();
 }

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/api/query/listen/QueryInfo.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/api/query/listen/QueryInfo.java
@@ -1,0 +1,32 @@
+/**
+ * 
+ */
+package org.codejargon.fluentjdbc.api.query.listen;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Information about what was executed - query + parameters. Parameters are not available for batch executions
+ * 
+ * @author bwc
+ */
+public interface QueryInfo {
+
+    /**
+     * @return the sql query which was executed
+     */
+    String sql();
+
+    /**
+     * @return optional parameters
+     */
+    Optional<List<Object>> params();
+
+    /**
+     * @return optional named parameters
+     */
+    Optional<Map<String, Object>> namedParams();
+
+}

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/BatchQueryInternal.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/BatchQueryInternal.java
@@ -1,28 +1,34 @@
 package org.codejargon.fluentjdbc.internal.query;
 
-import org.codejargon.fluentjdbc.api.FluentJdbcException;
-import org.codejargon.fluentjdbc.api.query.*;
-import org.codejargon.fluentjdbc.internal.query.namedparameter.NamedTransformedSql;
-import org.codejargon.fluentjdbc.internal.query.namedparameter.NamedTransformedSqlFactory;
-import org.codejargon.fluentjdbc.internal.support.Ints;
-import org.codejargon.fluentjdbc.internal.query.namedparameter.SqlAndParamsForNamed;
-import org.codejargon.fluentjdbc.internal.support.Preconditions;
+import static java.util.Optional.empty;
+import static java.util.stream.Collectors.toList;
+import static org.codejargon.fluentjdbc.internal.support.Iterables.stream;
+import static org.codejargon.fluentjdbc.internal.support.Sneaky.consumer;
 
-import java.awt.geom.AffineTransform;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static java.util.Optional.empty;
-import static java.util.stream.Collectors.toList;
-import static org.codejargon.fluentjdbc.internal.support.Sneaky.consumer;
-import static org.codejargon.fluentjdbc.internal.support.Iterables.stream;
+import org.codejargon.fluentjdbc.api.FluentJdbcException;
+import org.codejargon.fluentjdbc.api.query.BatchQuery;
+import org.codejargon.fluentjdbc.api.query.Mapper;
+import org.codejargon.fluentjdbc.api.query.SqlErrorHandler;
+import org.codejargon.fluentjdbc.api.query.UpdateResult;
+import org.codejargon.fluentjdbc.api.query.UpdateResultGenKeys;
+import org.codejargon.fluentjdbc.internal.query.namedparameter.NamedTransformedSql;
+import org.codejargon.fluentjdbc.internal.query.namedparameter.NamedTransformedSqlFactory;
+import org.codejargon.fluentjdbc.internal.query.namedparameter.SqlAndParamsForNamed;
+import org.codejargon.fluentjdbc.internal.support.Ints;
+import org.codejargon.fluentjdbc.internal.support.Preconditions;
 
 class BatchQueryInternal implements BatchQuery {
     private static final String namedSet = "Named parameters are already set.";
@@ -111,7 +117,7 @@ class BatchQueryInternal implements BatchQuery {
         Preconditions.checkArgument(params.isPresent() || namedParams.isPresent(), "Parameters must be set to run a batch query");
         return query.query(
                 connection -> params.isPresent() ? positional(connection, fetchGen) : named(connection, fetchGen),
-                Optional.of(sql),
+                Optional.of(QueryInfoInternal.of(sql)),
                 sqlErrorHandler.get()
         );
     }

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/CallableQueryInternal.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/CallableQueryInternal.java
@@ -1,0 +1,68 @@
+package org.codejargon.fluentjdbc.internal.query;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+
+import org.codejargon.fluentjdbc.api.FluentJdbcException;
+import org.codejargon.fluentjdbc.api.query.CallableMapper;
+import org.codejargon.fluentjdbc.api.query.CallableQuery;
+import org.codejargon.fluentjdbc.api.query.SqlErrorHandler;
+
+class CallableQueryInternal extends SingleQueryBase implements CallableQuery {
+
+    CallableQueryInternal(String sql, QueryInternal query) {
+        super(query, sql);
+    }
+
+    @Override
+    public CallableQuery params(List<?> params) {
+        addParameters(params);
+        return this;
+    }
+
+    @Override
+    public CallableQuery params(Object... params) {
+        addParameters(params);
+        return this;
+    }
+
+    @Override
+    public CallableQuery namedParams(Map<String, ?> namedParams) {
+        addNamedParameters(namedParams);
+        return this;
+    }
+
+    @Override
+    public CallableQuery namedParam(String name, Object parameter) {
+        addNamedParameter(name, parameter);
+        return this;
+    }
+
+    @Override
+    public CallableQuery errorHandler(SqlErrorHandler sqlErrorHandler ) {
+        this.sqlErrorHandler = () -> sqlErrorHandler;
+        return this;
+    }
+
+
+    @Override
+    public <T> T result(CallableMapper<T> mapper) {
+        return runQuery(ps -> {
+            if (ps instanceof CallableStatement) {
+                CallableStatement cs = (CallableStatement)ps;
+                cs.execute();
+                return mapper.map(cs);
+            } else {
+                throw new FluentJdbcException("No out parameters specified for call");
+            }
+        }, sqlErrorHandler.get());
+    }
+
+    @Override
+    void customizeQuery(PreparedStatement statement, QueryConfig config) throws SQLException {
+        // nothing to do here for callable statements
+    }
+}

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/DatabaseInspectionInternal.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/DatabaseInspectionInternal.java
@@ -18,7 +18,7 @@ class DatabaseInspectionInternal implements DatabaseInspection {
     public <T> T accessMetaData(MetaDataAccess<T> access) {
         return query.query(
                 connection -> access.access(connection.getMetaData()),
-                Optional.of(new QueryInfoInternal("JDBC Database Inspection", null, null)),
+                Optional.of(QueryInfoInternal.of("JDBC Database Inspection")),
                 query.config.defaultSqlErrorHandler.get()
         );
     }

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/DatabaseInspectionInternal.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/DatabaseInspectionInternal.java
@@ -1,11 +1,11 @@
 package org.codejargon.fluentjdbc.internal.query;
 
+import java.util.Optional;
+
 import org.codejargon.fluentjdbc.api.query.inspection.DatabaseInspection;
 import org.codejargon.fluentjdbc.api.query.inspection.MetaDataAccess;
 import org.codejargon.fluentjdbc.api.query.inspection.MetaDataResultSet;
 import org.codejargon.fluentjdbc.api.query.inspection.MetaDataSelect;
-
-import java.util.Optional;
 
 class DatabaseInspectionInternal implements DatabaseInspection {
     private final QueryInternal query;
@@ -18,7 +18,7 @@ class DatabaseInspectionInternal implements DatabaseInspection {
     public <T> T accessMetaData(MetaDataAccess<T> access) {
         return query.query(
                 connection -> access.access(connection.getMetaData()),
-                Optional.of("JDBC Database Inspection"),
+                Optional.of(new QueryInfoInternal("JDBC Database Inspection", null, null)),
                 query.config.defaultSqlErrorHandler.get()
         );
     }

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/DefaultSqlHandler.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/DefaultSqlHandler.java
@@ -1,13 +1,13 @@
 package org.codejargon.fluentjdbc.internal.query;
 
-import org.codejargon.fluentjdbc.api.query.SqlErrorHandler;
-
 import java.sql.SQLException;
 import java.util.Optional;
 
+import org.codejargon.fluentjdbc.api.query.SqlErrorHandler;
+
 public class DefaultSqlHandler implements SqlErrorHandler {
     @Override
-    public Action handle(SQLException e, Optional<String> sql) throws SQLException {
+    public Action handle(SQLException e, Optional<QueryInfoInternal> queryInfo) throws SQLException {
         throw e;
     }
 }

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/DefaultSqlHandler.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/DefaultSqlHandler.java
@@ -4,10 +4,11 @@ import java.sql.SQLException;
 import java.util.Optional;
 
 import org.codejargon.fluentjdbc.api.query.SqlErrorHandler;
+import org.codejargon.fluentjdbc.api.query.listen.QueryInfo;
 
 public class DefaultSqlHandler implements SqlErrorHandler {
     @Override
-    public Action handle(SQLException e, Optional<QueryInfoInternal> queryInfo) throws SQLException {
+    public Action handle(SQLException e, Optional<QueryInfo> queryInfo) throws SQLException {
         throw e;
     }
 }

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/ExecutionDetailsInternal.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/ExecutionDetailsInternal.java
@@ -1,20 +1,20 @@
 package org.codejargon.fluentjdbc.internal.query;
 
-import org.codejargon.fluentjdbc.api.query.listen.ExecutionDetails;
-
 import java.sql.SQLException;
 import java.util.Optional;
 
+import org.codejargon.fluentjdbc.api.query.listen.ExecutionDetails;
+
 class ExecutionDetailsInternal implements ExecutionDetails {
-    private final String sql;
+    private final QueryInfoInternal queryInfo;
     private final Long executionTimeMs;
     private final Optional<SQLException> sqlException;
 
     public ExecutionDetailsInternal(
-            String sql,
+            QueryInfoInternal queryInfo,
             Long executionTimeMs,
             Optional<SQLException> sqlException) {
-        this.sql = sql;
+        this.queryInfo = queryInfo;
         this.executionTimeMs = executionTimeMs;
         this.sqlException = sqlException;
     }
@@ -25,8 +25,8 @@ class ExecutionDetailsInternal implements ExecutionDetails {
     }
 
     @Override
-    public String sql() {
-        return sql;
+    public QueryInfoInternal queryInfo() {
+        return queryInfo;
     }
 
     @Override

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/ExecutionDetailsInternal.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/ExecutionDetailsInternal.java
@@ -4,14 +4,15 @@ import java.sql.SQLException;
 import java.util.Optional;
 
 import org.codejargon.fluentjdbc.api.query.listen.ExecutionDetails;
+import org.codejargon.fluentjdbc.api.query.listen.QueryInfo;
 
 class ExecutionDetailsInternal implements ExecutionDetails {
-    private final QueryInfoInternal queryInfo;
+    private final QueryInfo queryInfo;
     private final Long executionTimeMs;
     private final Optional<SQLException> sqlException;
 
     public ExecutionDetailsInternal(
-            QueryInfoInternal queryInfo,
+            QueryInfo queryInfo,
             Long executionTimeMs,
             Optional<SQLException> sqlException) {
         this.queryInfo = queryInfo;
@@ -25,7 +26,7 @@ class ExecutionDetailsInternal implements ExecutionDetails {
     }
 
     @Override
-    public QueryInfoInternal queryInfo() {
+    public QueryInfo queryInfo() {
         return queryInfo;
     }
 

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/PreparedStatementFactory.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/PreparedStatementFactory.java
@@ -1,5 +1,6 @@
 package org.codejargon.fluentjdbc.internal.query;
 
+import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -14,9 +15,11 @@ class PreparedStatementFactory {
         this.config = config;
     }
 
-    PreparedStatement createSingle(Connection con, SingleQueryBase singleQueryBase, boolean fetchGenerated, String[] genColumns) throws SQLException {
+    PreparedStatement createSingle(Connection con, SingleQueryBase singleQueryBase, boolean fetchGenerated,
+            String[] genColumns) throws SQLException {
         SqlAndParams sqlAndParams = singleQueryBase.sqlAndParams(config);
-        PreparedStatement statement = prepareStatement(con, sqlAndParams.sql(), fetchGenerated, genColumns);
+        PreparedStatement statement = sqlAndParams.hasOutParameters() ? prepareCall(con, sqlAndParams.sql())
+                : prepareStatement(con, sqlAndParams.sql(), fetchGenerated, genColumns);
         singleQueryBase.customizeQuery(statement, config);
         assignParams(statement, sqlAndParams.params());
         return statement;
@@ -39,7 +42,9 @@ class PreparedStatementFactory {
                 con.prepareStatement(sql);
     }
 
-
+    private CallableStatement prepareCall(Connection con, String sql) throws SQLException {
+        return con.prepareCall(sql);
+    }
 
 
 }

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/QueryInfoInternal.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/QueryInfoInternal.java
@@ -10,8 +10,9 @@ import java.util.Optional;
 import org.codejargon.fluentjdbc.api.query.listen.QueryInfo;
 
 /**
- * @author tono
- *
+ * Implementation of {@link QueryInfo}
+ * 
+ * @author bwc
  */
 public class QueryInfoInternal implements QueryInfo {
     private final String sql;
@@ -29,16 +30,16 @@ public class QueryInfoInternal implements QueryInfo {
         this.namedParams = namedParams;
     }
 
-    public static Optional<QueryInfoInternal> optional(String sql, List<Object> params, Map<String, Object> namedParams) {
+    public static Optional<QueryInfo> optional(String sql, List<Object> params, Map<String, Object> namedParams) {
         return Optional.of(of(sql, params, namedParams));
     }
 
-    public static QueryInfoInternal of(String sql, List<Object> params, Map<String, Object> namedParams) {
+    public static QueryInfo of(String sql, List<Object> params, Map<String, Object> namedParams) {
         return new QueryInfoInternal(sql, params.isEmpty() ? Optional.empty() : Optional.of(params), 
                         namedParams.isEmpty() ? Optional.empty() : Optional.of(namedParams));
     }
 
-    public static QueryInfoInternal of(String sql) {
+    public static QueryInfo of(String sql) {
         return new QueryInfoInternal(sql, Optional.empty(), Optional.empty());
     }
 

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/QueryInfoInternal.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/QueryInfoInternal.java
@@ -1,0 +1,68 @@
+/**
+ * 
+ */
+package org.codejargon.fluentjdbc.internal.query;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.codejargon.fluentjdbc.api.query.listen.QueryInfo;
+
+/**
+ * @author tono
+ *
+ */
+public class QueryInfoInternal implements QueryInfo {
+    private final String sql;
+    private final Optional<List<Object>> params;
+    private final Optional<Map<String, Object>> namedParams;
+
+    /**
+     * @param sql
+     * @param params
+     * @param namedParams
+     */
+    public QueryInfoInternal(String sql, Optional<List<Object>> params, Optional<Map<String, Object>> namedParams) {
+        this.sql = sql;
+        this.params = params;
+        this.namedParams = namedParams;
+    }
+
+    public static Optional<QueryInfoInternal> optional(String sql, List<Object> params, Map<String, Object> namedParams) {
+        return Optional.of(of(sql, params, namedParams));
+    }
+
+    public static QueryInfoInternal of(String sql, List<Object> params, Map<String, Object> namedParams) {
+        return new QueryInfoInternal(sql, params.isEmpty() ? Optional.empty() : Optional.of(params), 
+                        namedParams.isEmpty() ? Optional.empty() : Optional.of(namedParams));
+    }
+
+    public static QueryInfoInternal of(String sql) {
+        return new QueryInfoInternal(sql, Optional.empty(), Optional.empty());
+    }
+
+    /**
+     * @return the sql
+     */
+    @Override
+    public String sql() {
+        return sql;
+    }
+
+    /**
+     * @return the params
+     */
+    @Override
+    public Optional<List<Object>> params() {
+        return params;
+    }
+
+    /**
+     * @return the namedParams
+     */
+    @Override
+    public Optional<Map<String, Object>> namedParams() {
+        return namedParams;
+    }
+}

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/QueryInternal.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/QueryInternal.java
@@ -12,6 +12,7 @@ import org.codejargon.fluentjdbc.api.FluentJdbcException;
 import org.codejargon.fluentjdbc.api.FluentJdbcSqlException;
 import org.codejargon.fluentjdbc.api.integration.ConnectionProvider;
 import org.codejargon.fluentjdbc.api.query.BatchQuery;
+import org.codejargon.fluentjdbc.api.query.CallableQuery;
 import org.codejargon.fluentjdbc.api.query.PlainConnectionQuery;
 import org.codejargon.fluentjdbc.api.query.Query;
 import org.codejargon.fluentjdbc.api.query.SelectQuery;
@@ -52,6 +53,11 @@ public class QueryInternal implements Query {
         return new BatchQueryInternal(sql, this);
     }
 
+    @Override
+    public CallableQuery call(String sql) {
+        return new CallableQueryInternal(sql, this);
+    }
+    
     @Override
     public Transaction transaction() {
         return new TransactionInternal(this);

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/SelectQueryInternal.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/SelectQueryInternal.java
@@ -1,22 +1,28 @@
 package org.codejargon.fluentjdbc.internal.query;
 
+import static java.util.Optional.empty;
+import static org.codejargon.fluentjdbc.internal.support.Preconditions.checkArgument;
+import static org.codejargon.fluentjdbc.internal.support.Preconditions.checkNotNull;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
 import org.codejargon.fluentjdbc.api.FluentJdbcException;
 import org.codejargon.fluentjdbc.api.query.Mapper;
 import org.codejargon.fluentjdbc.api.query.SelectQuery;
 import org.codejargon.fluentjdbc.api.query.SqlConsumer;
 import org.codejargon.fluentjdbc.api.query.SqlErrorHandler;
 import org.codejargon.fluentjdbc.internal.support.Predicates;
-
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.*;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-
-import static java.util.Optional.empty;
-import static org.codejargon.fluentjdbc.internal.support.Preconditions.checkArgument;
-import static org.codejargon.fluentjdbc.internal.support.Preconditions.checkNotNull;
 
 class SelectQueryInternal extends SingleQueryBase implements SelectQuery {
 
@@ -105,7 +111,7 @@ class SelectQueryInternal extends SingleQueryBase implements SelectQuery {
     public <T> T singleResult(Mapper<T> mapper) {
         Optional<T> firstResult = firstResult(mapper);
         if (!firstResult.isPresent()) {
-            throw query.queryException(sql, Optional.of("At least one result expected"), empty());
+            throw query.queryException(QueryInfoInternal.optional(sql, params, namedParams), Optional.of("At least one result expected"), empty());
         }
         return firstResult.get();
     }

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/SingleQueryBase.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/SingleQueryBase.java
@@ -1,13 +1,17 @@
 package org.codejargon.fluentjdbc.internal.query;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
 import org.codejargon.fluentjdbc.api.query.SqlErrorHandler;
 import org.codejargon.fluentjdbc.internal.query.namedparameter.SqlAndParamsForNamed;
 import org.codejargon.fluentjdbc.internal.support.Preconditions;
-
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.util.*;
-import java.util.function.Supplier;
 
 abstract class SingleQueryBase {
     protected final String sql;
@@ -68,7 +72,7 @@ abstract class SingleQueryBase {
                     try (PreparedStatement ps = query.preparedStatementFactory.createSingle(connection, this, fetchGenerated, genColumns)) {
                         return queryRunnerPreparedStatement.run(ps);
                     }
-                }, Optional.of(sql),
+                }, QueryInfoInternal.optional(sql, params, namedParams),
                 sqlErrorHandler);
     }
 

--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/SqlAndParams.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/SqlAndParams.java
@@ -1,5 +1,6 @@
 package org.codejargon.fluentjdbc.internal.query;
 
+import java.sql.SQLType;
 import java.util.List;
 
 public class SqlAndParams {
@@ -17,5 +18,14 @@ public class SqlAndParams {
 
     List<Object> params() {
         return params;
+    }
+    
+    /**
+     * check whether parameters assume callable statement or prepared statement
+     * 
+     * @return true if at least one of parameters is out parameter
+     */
+    public boolean hasOutParameters() {
+        return params.parallelStream().anyMatch(param -> param instanceof SQLType);
     }
 }

--- a/fluent-jdbc/src/test/groovy/org/codejargon/fluentjdbc/internal/query/FluentJdbcCallTest.groovy
+++ b/fluent-jdbc/src/test/groovy/org/codejargon/fluentjdbc/internal/query/FluentJdbcCallTest.groovy
@@ -1,0 +1,78 @@
+package org.codejargon.fluentjdbc.internal.query
+
+import org.codejargon.fluentjdbc.api.FluentJdbcException
+import org.codejargon.fluentjdbc.api.query.CallableMapper;
+import org.codejargon.fluentjdbc.api.FluentJdbcBuilder;
+import org.codejargon.fluentjdbc.api.query.Query
+import org.junit.Test
+import spock.lang.Specification
+
+import javax.naming.OperationNotSupportedException;
+import java.sql.Connection
+import java.sql.ParameterMetaData;
+import java.sql.CallableStatement;
+import java.sql.SQLException
+import java.sql.Types;
+import java.util.*
+
+class FluentJdbcCallTest  extends Specification {
+
+    static String result1 = "res"
+    static String param1 = "lille"
+    static String param2 = "lamb"
+
+    def connection = Mock(Connection)
+    def callableStatement = Mock(CallableStatement)
+
+    Query query;
+
+    def setup() {
+        query = new FluentJdbcBuilder().connectionProvider(
+                { q -> q.receive(connection)}
+        ).build().query();
+    }
+
+    def "Call with ordered parameters"() {
+        given:
+        def sql = "{? = call pack.func(?, ?)}"
+        connection.prepareCall(sql) >> callableStatement
+        mockSelectData()
+        def orderedParams = [java.sql.JDBCType.VARCHAR, param1, param2]
+        when:
+        query.call(sql).params(orderedParams).result(dummyMapper)
+        then:
+        1 * callableStatement.registerOutParameter(1, java.sql.JDBCType.VARCHAR)
+        1 * callableStatement.setObject(2, param1)
+        1 * callableStatement.setObject(3, param2)
+    }
+
+    def "Call with named parameters"() {
+        given:
+        def namedParamSql = "{:outPar = call pack.func(:param1, :param2, :param1)}"
+        def expectedSql = "{? = call pack.func(?, ?, ?)}"
+        connection.prepareCall(expectedSql) >> callableStatement
+        mockSelectData()
+        def namedParams = ["param1": param1, "outPar": java.sql.JDBCType.VARCHAR, "param2": param2]
+        when:
+        query.call(namedParamSql).namedParams(namedParams).result(dummyMapper)
+        then:
+        1 * callableStatement.registerOutParameter(1, java.sql.JDBCType.VARCHAR)
+        1 * callableStatement.setObject(2, param1)
+        1 * callableStatement.setObject(3, param2)
+        1 * callableStatement.setObject(4, param1)
+    }
+
+    private void mockSelectData() {
+        callableStatement.getString(1) >> result1
+    }
+
+    static CallableMapper<Dummy> dummyMapper = { cs -> new Dummy(cs.getString(1)) }
+
+    static class Dummy {
+        final String foo
+
+        Dummy(String foo) {
+            this.foo = foo
+        }
+    }
+}

--- a/fluent-jdbc/src/test/groovy/org/codejargon/fluentjdbc/internal/query/QueryListenerTest.groovy
+++ b/fluent-jdbc/src/test/groovy/org/codejargon/fluentjdbc/internal/query/QueryListenerTest.groovy
@@ -35,7 +35,7 @@ class QueryListenerTest extends Specification {
         then:
         executionDetails != null
         executionDetails.success()
-        executionDetails.sql() == sql
+        executionDetails.queryInfo().sql() == sql
         executionDetails.executionTimeMs() >= 0
         !executionDetails.sqlException().isPresent()
     }
@@ -49,7 +49,7 @@ class QueryListenerTest extends Specification {
         thrown(FluentJdbcSqlException)
         executionDetails != null
         !executionDetails.success()
-        executionDetails.sql() == sql
+        executionDetails.queryInfo().sql() == sql
         executionDetails.executionTimeMs() >= 0
         executionDetails.sqlException().isPresent()
     }


### PR DESCRIPTION
Introducing QueryInfo to convey more than just SQL statement to the listener. This allows listener to log all basic information relevant to query execution (statement, parameters, execution time, error)

This changes API for SqlErrorHandler and ExecutionDetails and can be breaking for users.