### PR TITLE
Don't throw exception if transaction is empty

### DIFF
--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/TransactionInternal.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/TransactionInternal.java
@@ -1,6 +1,5 @@
 package org.codejargon.fluentjdbc.internal.query;
 
-import org.codejargon.fluentjdbc.api.FluentJdbcException;
 import org.codejargon.fluentjdbc.api.FluentJdbcSqlException;
 import org.codejargon.fluentjdbc.api.integration.ConnectionProvider;
 import org.codejargon.fluentjdbc.api.query.Transaction;
@@ -63,7 +62,9 @@ class TransactionInternal implements Transaction {
                                 }
                                 throw e;
                             }
-                            con.commit();
+                            if (!con.getAutoCommit()) {
+                                con.commit();
+                            }
                         } catch(SQLException e) {
                             throw new FluentJdbcSqlException("Error executing transaction", e);
                         } finally {

--- a/fluent-jdbc/src/test/groovy/org/codejargon/fluentjdbc/internal/query/FluentJdbcTransactionTest.groovy
+++ b/fluent-jdbc/src/test/groovy/org/codejargon/fluentjdbc/internal/query/FluentJdbcTransactionTest.groovy
@@ -124,6 +124,27 @@ class FluentJdbcTransactionTest extends UpdateTestBase {
         1 * connection.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE)
     }
 
+    def "Empty transaction doesn't throw exception"() {
+        given:
+        preparedStatement.executeUpdate() >> expectedUpdatedRows.intValue()
+        when:
+        query.transaction().in(
+                { ->
+                    // no queries
+                }
+        )
+        then:
+        // checking original state, then check before commit
+        connection.getAutoCommit() >> true >> true
+
+        _ * connection.getAutoCommit()
+        0 * connection.setAutoCommit(false)
+        0 * preparedStatement.close()
+        0 * connection.rollback()
+        0 * connection.commit()
+        1 * connection.setAutoCommit(true)
+    }
+
     def throwException() {
         throw new MyRuntimeException()
     }


### PR DESCRIPTION
I suggest avoiding throwing an exception if there were no queries inside a transaction.

Resolves [#87](https://github.com/zsoltherpai/fluent-jdbc/issues/87)