### PR TITLE
Change Optional.of() to null-safe Optional.ofNullable() in SelectQueryInternal#firstResult

### DIFF
--- a/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/SelectQueryInternal.java
+++ b/fluent-jdbc/src/main/java/org/codejargon/fluentjdbc/internal/query/SelectQueryInternal.java
@@ -91,7 +91,7 @@ class SelectQueryInternal extends SingleQueryBase implements SelectQuery {
                         while (rs.next() && !result.isPresent()) {
                             T candidate = mapper.map(rs);
                             if (filter.test(candidate)) {
-                                result = Optional.of(candidate);
+                                result = Optional.ofNullable(candidate);
                             }
                         }
                         return result;


### PR DESCRIPTION
The method SelectQueryInternal#firstResult will cause a NullPointerException if the Mapper returns a null object and the Predicate does not exclude this null object. Changing the Optional.of() call to Optional.ofNullable() would prevent a NullPointerException from being thrown.